### PR TITLE
Add US stock price search page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,17 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Stock Price API
+
+This project exposes a simple endpoint to fetch current U.S. stock prices.
+
+Send a GET request to `/api/stocks?symbol=SYMBOL` where `SYMBOL` is the stock ticker. The data is retrieved from the free [Stooq](https://stooq.com/) service and returned as JSON.
+
+Example:
+
+```bash
+curl http://localhost:3000/api/stocks?symbol=AAPL
+```
+
+You can also test it in the browser by visiting `/stocks` and searching for a ticker symbol.

--- a/app/api/stocks/route.ts
+++ b/app/api/stocks/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const symbol = searchParams.get('symbol');
+  if (!symbol) {
+    return Response.json({ error: 'Missing symbol parameter' }, { status: 400 });
+  }
+
+  const url = `https://stooq.pl/q/l/?s=${symbol.toLowerCase()}.us`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      return Response.json({ error: 'Failed to fetch data' }, { status: 500 });
+    }
+    const csv = await res.text();
+    const [line] = csv.trim().split('\n');
+    const [ticker, date, time, open, high, low, close, volume] = line.split(',');
+    return Response.json({
+      ticker,
+      date,
+      time,
+      open: parseFloat(open),
+      high: parseFloat(high),
+      low: parseFloat(low),
+      close: parseFloat(close),
+      volume: parseInt(volume, 10)
+    });
+  } catch (e: any) {
+    return Response.json({ error: 'Unexpected error' }, { status: 500 });
+  }
+}

--- a/app/stocks/page.tsx
+++ b/app/stocks/page.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function StockSearchPage() {
+  const [symbol, setSymbol] = useState('')
+  const [data, setData] = useState<any | null>(null)
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const fetchPrice = async () => {
+    if (!symbol) return
+    setLoading(true)
+    setError('')
+    setData(null)
+    try {
+      const res = await fetch(`/api/stocks?symbol=${symbol}`)
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || 'Failed to fetch')
+      setData(json)
+    } catch (e: any) {
+      setError(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="p-8 flex flex-col gap-4 max-w-md mx-auto">
+      <h1 className="text-2xl font-bold">Stock Price Lookup</h1>
+      <div className="flex gap-2">
+        <input
+          className="border px-2 py-1 flex-1 rounded"
+          value={symbol}
+          onChange={e => setSymbol(e.target.value)}
+          placeholder="Enter symbol e.g. AAPL"
+        />
+        <button
+          className="border px-4 rounded disabled:opacity-50"
+          onClick={fetchPrice}
+          disabled={loading}
+        >
+          {loading ? 'Loading...' : 'Search'}
+        </button>
+      </div>
+      {error && <p className="text-red-600">{error}</p>}
+      {data && (
+        <div className="border p-4 rounded">
+          <p><strong>{data.ticker}</strong></p>
+          <p>Price: {data.close}</p>
+          <p>Date: {data.date} {data.time}</p>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `/stocks` page to search stock quotes using the API
- mention the page in README

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_683f9ccfafa8832fb7864d7be55debf2