### PR TITLE
Add stock price history API

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,20 @@ curl http://localhost:3000/api/stocks?symbol=AAPL
 ```
 
 You can also test it in the browser by visiting `/stocks` and searching for a ticker symbol.
+
+## Stock Price History API
+
+Fetch historical prices by sending a GET request to `/api/stocks/history` with the following query parameters:
+
+- `symbol` – stock ticker symbol (required)
+- `from` – start date/time in ISO format (required)
+- `to` – end date/time in ISO format (required)
+- `unit` – data granularity: `5min`, `1hour`, or `day` (defaults to `day`)
+
+Example:
+
+```bash
+curl "http://localhost:3000/api/stocks/history?symbol=IBM&from=2025-05-01&to=2025-05-10&unit=day"
+```
+
+The API uses [Alpha Vantage](https://www.alphavantage.co/) under the hood. Set the `ALPHAVANTAGE_API_KEY` environment variable to use your own key; otherwise the `demo` key is used with limited data.

--- a/app/api/stocks/history/route.ts
+++ b/app/api/stocks/history/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest } from 'next/server'
+
+const API_KEY = process.env.ALPHAVANTAGE_API_KEY || 'demo'
+
+function parseDate(value: string | null) {
+  if (!value) return null
+  const date = new Date(value)
+  return isNaN(date.getTime()) ? null : date
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const symbol = searchParams.get('symbol')
+  const from = parseDate(searchParams.get('from'))
+  const to = parseDate(searchParams.get('to'))
+  const unit = searchParams.get('unit') || 'day'
+
+  if (!symbol) {
+    return Response.json({ error: 'Missing symbol parameter' }, { status: 400 })
+  }
+  if (!from || !to) {
+    return Response.json({ error: 'from and to parameters are required and must be valid dates' }, { status: 400 })
+  }
+  if (from > to) {
+    return Response.json({ error: 'from must be before to' }, { status: 400 })
+  }
+
+  let url: string
+  if (unit === '5min' || unit === '1hour') {
+    const interval = unit === '5min' ? '5min' : '60min'
+    url = `https://www.alphavantage.co/query?function=TIME_SERIES_INTRADAY&symbol=${symbol}&interval=${interval}&outputsize=full&apikey=${API_KEY}`
+  } else if (unit === 'day') {
+    url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol=${symbol}&outputsize=full&apikey=${API_KEY}`
+  } else {
+    return Response.json({ error: 'Invalid unit parameter' }, { status: 400 })
+  }
+
+  try {
+    const res = await fetch(url)
+    if (!res.ok) {
+      return Response.json({ error: 'Failed to fetch data' }, { status: 500 })
+    }
+    const data = await res.json()
+
+    const seriesKey = unit === 'day' ? 'Time Series (Daily)' : unit === '5min' ? 'Time Series (5min)' : 'Time Series (60min)'
+    const series = data[seriesKey]
+    if (!series) {
+      return Response.json({ error: 'Unexpected response from data provider' }, { status: 500 })
+    }
+
+    const results = Object.entries(series)
+      .map(([timestamp, values]) => ({
+        timestamp,
+        open: parseFloat((values as any)['1. open']),
+        high: parseFloat((values as any)['2. high']),
+        low: parseFloat((values as any)['3. low']),
+        close: parseFloat((values as any)['4. close']),
+        volume: parseInt((values as any)['5. volume'], 10)
+      }))
+      .filter(r => {
+        const t = new Date(r.timestamp)
+        return t >= from && t <= to
+      })
+      .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+
+    return Response.json({ symbol, unit, data: results })
+  } catch (e: any) {
+    return Response.json({ error: 'Unexpected error' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- add new `/api/stocks/history` route for querying historical prices
- document the stock history API usage

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_683fcaa18414832fa59b58cd4c485ec5