### PR TITLE
Add history search to stock page

### DIFF
--- a/app/stocks/page.tsx
+++ b/app/stocks/page.tsx
@@ -1,12 +1,24 @@
 'use client'
 
 import { useState } from 'react'
+import DateSelect from '@/components/date-select'
 
 export default function StockSearchPage() {
   const [symbol, setSymbol] = useState('')
   const [data, setData] = useState<any | null>(null)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
+
+  const yesterday = new Date()
+  yesterday.setDate(yesterday.getDate() - 1)
+  const today = new Date()
+
+  const [from, setFrom] = useState(yesterday.toISOString().slice(0, 16))
+  const [to, setTo] = useState(today.toISOString().slice(0, 16))
+  const [unit, setUnit] = useState('1hour')
+  const [history, setHistory] = useState<any[] | null>(null)
+  const [historyError, setHistoryError] = useState('')
+  const [historyLoading, setHistoryLoading] = useState(false)
 
   const fetchPrice = async () => {
     if (!symbol) return
@@ -22,6 +34,29 @@ export default function StockSearchPage() {
       setError(e.message)
     } finally {
       setLoading(false)
+    }
+  }
+
+  const fetchHistory = async () => {
+    if (!symbol) return
+    setHistoryLoading(true)
+    setHistoryError('')
+    setHistory(null)
+    try {
+      const params = new URLSearchParams({
+        symbol,
+        from,
+        to,
+        unit,
+      })
+      const res = await fetch(`/api/stocks/history?${params.toString()}`)
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || 'Failed to fetch')
+      setHistory(json.data)
+    } catch (e: any) {
+      setHistoryError(e.message)
+    } finally {
+      setHistoryLoading(false)
     }
   }
 
@@ -50,6 +85,31 @@ export default function StockSearchPage() {
           <p>Price: {data.close}</p>
           <p>Date: {data.date} {data.time}</p>
         </div>
+      )}
+
+      <h2 className="text-xl font-bold mt-6">History</h2>
+      <DateSelect
+        from={from}
+        to={to}
+        unit={unit}
+        setFrom={setFrom}
+        setTo={setTo}
+        setUnit={setUnit}
+      />
+      <button
+        className="border px-4 rounded disabled:opacity-50 mt-2"
+        onClick={fetchHistory}
+        disabled={historyLoading}
+      >
+        {historyLoading ? 'Loading...' : 'Search History'}
+      </button>
+      {historyError && <p className="text-red-600">{historyError}</p>}
+      {history && (
+        <ul className="border p-4 rounded space-y-1 text-sm font-mono overflow-x-auto">
+          {history.map((item, idx) => (
+            <li key={idx}>{JSON.stringify(item)}</li>
+          ))}
+        </ul>
       )}
     </div>
   )

--- a/components/date-select.tsx
+++ b/components/date-select.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+
+interface DateSelectProps {
+  from: string
+  to: string
+  unit: string
+  setFrom: (v: string) => void
+  setTo: (v: string) => void
+  setUnit: (v: string) => void
+}
+
+export default function DateSelect({ from, to, unit, setFrom, setTo, setUnit }: DateSelectProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex gap-2">
+        <label className="flex flex-col flex-1">
+          <span className="text-sm">From</span>
+          <input
+            type="datetime-local"
+            value={from}
+            onChange={e => setFrom(e.target.value)}
+            className="border px-2 py-1 rounded"
+          />
+        </label>
+        <label className="flex flex-col flex-1">
+          <span className="text-sm">To</span>
+          <input
+            type="datetime-local"
+            value={to}
+            onChange={e => setTo(e.target.value)}
+            className="border px-2 py-1 rounded"
+          />
+        </label>
+      </div>
+      <label className="flex flex-col w-32">
+        <span className="text-sm">Interval</span>
+        <select
+          value={unit}
+          onChange={e => setUnit(e.target.value)}
+          className="border px-2 py-1 rounded"
+        >
+          <option value="5min">5 min</option>
+          <option value="1hour">1 hour</option>
+          <option value="day">1 day</option>
+        </select>
+      </label>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `DateSelect` component for date range and interval selection
- enhance `/stocks` page with stock history search using history API

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_683fccf82cd4832f800426fb04786505