### PR TITLE
Add stock chart component

### DIFF
--- a/app/stocks/page.tsx
+++ b/app/stocks/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import DateSelect from '@/components/date-select'
+import StockChart from '@/components/stock-chart'
 
 export default function StockSearchPage() {
   const [symbol, setSymbol] = useState('')
@@ -105,11 +106,9 @@ export default function StockSearchPage() {
       </button>
       {historyError && <p className="text-red-600">{historyError}</p>}
       {history && (
-        <ul className="border p-4 rounded space-y-1 text-sm font-mono overflow-x-auto">
-          {history.map((item, idx) => (
-            <li key={idx}>{JSON.stringify(item)}</li>
-          ))}
-        </ul>
+        <div className="border p-4 rounded">
+          <StockChart data={history} />
+        </div>
       )}
     </div>
   )

--- a/components/stock-chart.tsx
+++ b/components/stock-chart.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import React from "react";
+import dynamic from "next/dynamic";
+import type { UTCTimestamp } from "lightweight-charts";
+
+const Chart = dynamic(
+  () => import("lightweight-charts-react-wrapper").then((m) => m.Chart),
+  { ssr: false },
+);
+const CandlestickSeries = dynamic(
+  () =>
+    import("lightweight-charts-react-wrapper").then((m) => m.CandlestickSeries),
+  { ssr: false },
+);
+
+export interface HistoryItem {
+  timestamp: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+interface StockChartProps {
+  data: HistoryItem[];
+}
+
+export default function StockChart({ data }: StockChartProps) {
+  const seriesData = React.useMemo(
+    () =>
+      data.map((item) => ({
+        time: Math.floor(
+          new Date(item.timestamp).getTime() / 1000,
+        ) as UTCTimestamp,
+        open: item.open,
+        high: item.high,
+        low: item.low,
+        close: item.close,
+      })),
+    [data],
+  );
+
+  return (
+    <Chart autoSize height={300}>
+      <CandlestickSeries data={seriesData} reactive />
+    </Chart>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -12,11 +12,14 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "lightweight-charts": "^5.0.7",
+    "lightweight-charts-react-wrapper": "^2.1.1",
     "lucide-react": "^0.512.0",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwind-merge": "^3.3.0"
+    "tailwind-merge": "^3.3.0",
+    "tslib": "^2.8.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      lightweight-charts:
+        specifier: ^5.0.7
+        version: 5.0.7
+      lightweight-charts-react-wrapper:
+        specifier: ^2.1.1
+        version: 2.1.1(lightweight-charts@5.0.7)(react@19.1.0)(tslib@2.8.1)
       lucide-react:
         specifier: ^0.512.0
         version: 0.512.0(react@19.1.0)
@@ -29,6 +35,9 @@ importers:
       tailwind-merge:
         specifier: ^3.3.0
         version: 3.3.0
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -980,6 +989,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  fancy-canvas@2.1.0:
+    resolution: {integrity: sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1350,6 +1362,16 @@ packages:
   lightningcss@1.30.1:
     resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
     engines: {node: '>= 12.0.0'}
+
+  lightweight-charts-react-wrapper@2.1.1:
+    resolution: {integrity: sha512-L+iyvHeM6+9yuSsbPRX5WiAx5m/Wg3JutstfYv3QjfSvyBE0cc5F4JPQD6k4e3OvZrvluq935/8ku3x8k5XB6Q==}
+    peerDependencies:
+      lightweight-charts: '>=4.0.0'
+      react: '>=16.8.0'
+      tslib: '*'
+
+  lightweight-charts@5.0.7:
+    resolution: {integrity: sha512-A4GqwYKRLhZREJEsSpORNNIWceOy5TS30s/WdAP2apKCDhAcIZDAI76TQHCCSf60oHwM7B92exXdQS9UykjXhw==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -2856,6 +2878,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  fancy-canvas@2.1.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -3222,6 +3246,16 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.1
       lightningcss-win32-arm64-msvc: 1.30.1
       lightningcss-win32-x64-msvc: 1.30.1
+
+  lightweight-charts-react-wrapper@2.1.1(lightweight-charts@5.0.7)(react@19.1.0)(tslib@2.8.1):
+    dependencies:
+      lightweight-charts: 5.0.7
+      react: 19.1.0
+      tslib: 2.8.1
+
+  lightweight-charts@5.0.7:
+    dependencies:
+      fancy-canvas: 2.1.0
 
   locate-path@6.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- install lightweight-charts and wrapper
- create `StockChart` component for candlestick charts
- render chart on stock history search page
- fix dynamic imports for the chart to avoid runtime errors

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_683fd865364c832faac0a815601d0acb