### PR TITLE
Add test workflow and ignore tests in typecheck

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec vitest run

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,10 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules",
+    "test",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ]
 }


### PR DESCRIPTION
## Summary
- create a workflow to run unit tests
- exclude test files from the TypeScript config so typecheck doesn't see them

## Testing
- `pnpm exec tsc -p tsconfig.json`
- `pnpm run lint`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6840166e2400832faa00e564f4ffc12a