### PR TITLE
Add tabbed chart/raw history view

### DIFF
--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import React from "react"
+
+export interface TabItem {
+  label: string
+  value: string
+}
+
+interface TabsProps {
+  tabs: TabItem[]
+  value: string
+  onChange: (value: string) => void
+  className?: string
+}
+
+export default function Tabs({ tabs, value, onChange, className }: TabsProps) {
+  return (
+    <div className={cn("flex border-b", className)}>
+      {tabs.map(tab => (
+        <button
+          key={tab.value}
+          onClick={() => onChange(tab.value)}
+          className={cn(
+            "px-4 py-2 text-sm -mb-px border-b-2",
+            tab.value === value
+              ? "border-primary text-primary"
+              : "border-transparent text-muted-foreground hover:text-foreground hover:border-border"
+          )}
+          type="button"
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/components/history-search.tsx
+++ b/components/history-search.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useMemo, startTransition, Suspense, use } from 'react'
 import DateSelect from '@/components/date-select'
+import Tabs, { TabItem } from '@/components/Tabs'
+import ChartView from '@/components/chart-view'
 
 interface HistorySearchProps {
   symbolInput: string
@@ -79,16 +81,32 @@ export default function HistorySearch({ symbolInput }: HistorySearchProps) {
 
 function HistoryResult({ promise }: { promise: Promise<HistoryItem[] | HistoryError> }) {
   const result = use(promise)
+  const [view, setView] = useState<'raw' | 'chart'>('raw')
+
   if ('error' in result) {
     return <p className="text-red-600">{result.error}</p>
   }
+
   const history = result
+
+  const tabs: TabItem[] = [
+    { label: 'Raw', value: 'raw' },
+    { label: 'Chart', value: 'chart' },
+  ]
+
   return (
-    <ul className="border p-4 rounded space-y-1 text-sm font-mono overflow-x-auto">
-      {history.map((item, idx) => (
-        <li key={idx}>{JSON.stringify(item)}</li>
-      ))}
-    </ul>
+    <div className="mt-4 space-y-4">
+      <Tabs tabs={tabs} value={view} onChange={(v) => setView(v as 'raw' | 'chart')} />
+      {view === 'raw' ? (
+        <ul className="border p-4 rounded space-y-1 text-sm font-mono overflow-x-auto">
+          {history.map((item, idx) => (
+            <li key={idx}>{JSON.stringify(item)}</li>
+          ))}
+        </ul>
+      ) : (
+        <ChartView data={history} />
+      )}
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- add a simple `Tabs` component
- allow history results to toggle between raw data and a chart view

## Testing
- `pnpm typecheck`
- `pnpm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_684034339618832fbf9cb06f9563e644