### PR TITLE
Fix repeated stock search

### DIFF
--- a/app/stocks/page.tsx
+++ b/app/stocks/page.tsx
@@ -20,12 +20,14 @@ interface PriceError {
 
 export default function StockSearchPage() {
   const [symbolInput, setSymbolInput] = useState('')
-  const [searchSymbol, setSearchSymbol] = useState<string | null>(null)
+  const [searchSymbol, setSearchSymbol] = useState<
+    { symbol: string; id: number } | null
+  >(null)
 
 
   const pricePromise = useMemo<Promise<StockPrice | PriceError> | null>(() => {
     if (!searchSymbol) return null
-    return fetch(`/api/stocks?symbol=${searchSymbol}`)
+    return fetch(`/api/stocks?symbol=${searchSymbol.symbol}`)
       .then(async res => {
         const json: StockPrice | PriceError = await res.json()
         if (!res.ok) return { error: (json as PriceError).error || 'Failed to fetch' }
@@ -38,7 +40,7 @@ export default function StockSearchPage() {
   const searchPrice = () => {
     if (!symbolInput.trim()) return
     startTransition(() => {
-      setSearchSymbol(symbolInput.trim())
+      setSearchSymbol({ symbol: symbolInput.trim(), id: Date.now() })
     })
   }
 

--- a/components/history-search.tsx
+++ b/components/history-search.tsx
@@ -29,14 +29,15 @@ export default function HistorySearch({ symbolInput }: HistorySearchProps) {
   const [to, setTo] = useState(today.toISOString().slice(0, 16))
   const [unit, setUnit] = useState('1hour')
   const [historyParams, setHistoryParams] = useState<
-    { symbol: string; from: string; to: string; unit: string } | null
+    { symbol: string; from: string; to: string; unit: string; id: number } | null
   >(null)
 
   const historyPromise = useMemo<
     Promise<HistoryItem[] | HistoryError> | null
   >(() => {
     if (!historyParams) return null
-    const params = new URLSearchParams(historyParams).toString()
+    const { id: _id, ...query } = historyParams
+    const params = new URLSearchParams(query).toString()
     return fetch(`/api/stocks/history?${params}`)
       .then(async res => {
         const json: { data: HistoryItem[] } & Partial<HistoryError> =
@@ -50,7 +51,13 @@ export default function HistorySearch({ symbolInput }: HistorySearchProps) {
   const searchHistory = () => {
     if (!symbolInput.trim()) return
     startTransition(() => {
-      setHistoryParams({ symbol: symbolInput.trim(), from, to, unit })
+      setHistoryParams({
+        symbol: symbolInput.trim(),
+        from,
+        to,
+        unit,
+        id: Date.now(),
+      })
     })
   }
 


### PR DESCRIPTION
## Summary
- add a timestamp to stock price search params so repeated searches fetch again
- add a timestamp to history search params

## Testing
- `pnpm typecheck`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68406f69ca6c832f9fddcd45d75103a2