### PR TITLE
refactor/stocks: move StockPrice type to utils

### DIFF
--- a/app/stocks/page.tsx
+++ b/app/stocks/page.tsx
@@ -2,17 +2,7 @@
 
 import { useState, startTransition, Suspense, use } from 'react'
 import HistorySearch from '@/components/history-search'
-
-interface StockPrice {
-  ticker: string
-  date: string
-  time: string
-  open: number
-  high: number
-  low: number
-  close: number
-  volume: number
-}
+import { StockPrice } from '@/utils/types'
 
 interface PriceError {
   error: string

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,0 +1,10 @@
+export interface StockPrice {
+  ticker: string
+  date: string
+  time: string
+  open: number
+  high: number
+  low: number
+  close: number
+  volume: number
+}


### PR DESCRIPTION
## Summary
- create `utils/types.ts` with a shared `StockPrice` interface
- import the new type in the stocks page

## Testing
- `pnpm typecheck`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_684150720fbc832f82ec3e501c365c9f