### PR TITLE
feat(showcase): fix chart color and nav

### DIFF
--- a/app/showcase/page.tsx
+++ b/app/showcase/page.tsx
@@ -1,0 +1,73 @@
+import ChartView from '@/components/chart-view'
+import type { StockPrice } from '@/lib/types'
+
+const mockPrices: StockPrice[] = [
+  {
+    ticker: 'ACME',
+    date: '2024-01-01',
+    time: '09:00:00',
+    open: 1,
+    high: 1.2,
+    low: 0.8,
+    close: 1.1,
+    volume: 500,
+  },
+  {
+    ticker: 'ACME',
+    date: '2024-01-02',
+    time: '09:00:00',
+    open: 1.1,
+    high: 1.3,
+    low: 1.0,
+    close: 1.25,
+    volume: 700,
+  },
+  {
+    ticker: 'ACME',
+    date: '2024-01-03',
+    time: '09:00:00',
+    open: 1.25,
+    high: 1.4,
+    low: 1.1,
+    close: 1.3,
+    volume: 650,
+  },
+  {
+    ticker: 'ACME',
+    date: '2024-01-04',
+    time: '09:00:00',
+    open: 1.3,
+    high: 1.45,
+    low: 1.2,
+    close: 1.4,
+    volume: 800,
+  },
+  {
+    ticker: 'ACME',
+    date: '2024-01-05',
+    time: '09:00:00',
+    open: 1.4,
+    high: 1.6,
+    low: 1.3,
+    close: 1.55,
+    volume: 750,
+  },
+]
+
+const historyData = mockPrices.map(p => ({
+  timestamp: `${p.date} ${p.time}`,
+  open: p.open,
+  high: p.high,
+  low: p.low,
+  close: p.close,
+  volume: p.volume,
+}))
+
+export default function ShowcasePage() {
+  return (
+    <div className="p-8 space-y-4">
+      <h1 className="text-2xl font-bold">Chart Showcase</h1>
+      <ChartView data={historyData} />
+    </div>
+  )
+}

--- a/app/stocks/page.tsx
+++ b/app/stocks/page.tsx
@@ -2,17 +2,7 @@
 
 import { useState, startTransition, Suspense, use } from 'react'
 import HistorySearch from '@/components/history-search'
-
-interface StockPrice {
-  ticker: string
-  date: string
-  time: string
-  open: number
-  high: number
-  low: number
-  close: number
-  volume: number
-}
+import type { StockPrice } from '@/lib/types'
 
 interface PriceError {
   error: string

--- a/components/chart-view.tsx
+++ b/components/chart-view.tsx
@@ -31,7 +31,7 @@ export default function ChartView({ data }: { data: StockHistoryItem[] }) {
 
     const series = chart.addSeries(LineSeries, {
       lineWidth: 2,
-      color: "hsl(var(--chart-1))",
+      color: "var(--chart-1)",
     })
 
     const lineData: LineData[] = data.map(item => ({

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -68,6 +68,9 @@ export default function Navbar() {
             <Link href="/stocks" onClick={() => setOpen(false)}>
               Stocks
             </Link>
+            <Link href="/showcase" onClick={() => setOpen(false)}>
+              Showcase
+            </Link>
           </nav>
         </div>
       </div>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,10 @@
+export interface StockPrice {
+  ticker: string
+  date: string
+  time: string
+  open: number
+  high: number
+  low: number
+  close: number
+  volume: number
+}


### PR DESCRIPTION
## Summary
- fix chart colors by removing `hsl()` wrapper
- add Showcase link to navbar

## Testing
- `pnpm typecheck`
- `pnpm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_684150465700832fb23be984d9d8db08