### PR TITLE
feature/button-hover-style

### DIFF
--- a/app/stocks/page.tsx
+++ b/app/stocks/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, startTransition, Suspense, use } from 'react'
 import HistorySearch from '@/components/history-search'
+import { Button } from '@/components/ui/button'
 import { StockPrice } from '@/utils/types'
 
 interface PriceError {
@@ -39,9 +40,9 @@ export default function StockSearchPage() {
           onChange={e => setSymbolInput(e.target.value)}
           placeholder="Enter symbol e.g. AAPL"
         />
-        <button className="border px-4 rounded" onClick={searchPrice}>
+        <Button onClick={searchPrice}>
           Search
-        </button>
+        </Button>
       </div>
       {pricePromise && (
         <Suspense fallback={<p>Loading...</p>}>

--- a/components/history-search.tsx
+++ b/components/history-search.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo, startTransition, Suspense, use } from 'react'
 import DateSelect from '@/components/date-select'
 import ChartView from '@/components/chart-view'
+import { Button } from '@/components/ui/button'
 
 interface HistorySearchProps {
   symbolInput: string
@@ -66,9 +67,9 @@ export default function HistorySearch({ symbolInput }: HistorySearchProps) {
         setTo={setTo}
         setUnit={setUnit}
       />
-      <button className="border px-4 rounded mt-2" onClick={searchHistory}>
+      <Button className="mt-2" onClick={searchHistory}>
         Search History
-      </button>
+      </Button>
       {historyPromise && (
         <Suspense fallback={<p>Loading...</p>}>
           <HistoryResult promise={historyPromise} />

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Menu, X } from "lucide-react";
 import { Breadcrumb, BreadcrumbItem } from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
 import { fade, slideLeft } from "@/lib/transitions";
 import { cn } from "@/lib/utils";
 
@@ -26,13 +27,13 @@ export default function Navbar() {
   return (
     <header className="sticky top-0 z-50 border-b bg-background">
       <div className="container mx-auto flex items-center gap-4 p-4">
-        <button
+        <Button
           aria-label="Toggle Menu"
           className="md:hidden"
           onClick={() => setOpen(true)}
         >
           <Menu className="h-6 w-6" />
-        </button>
+        </Button>
         <Breadcrumb items={items} />
       </div>
       <div
@@ -54,13 +55,13 @@ export default function Navbar() {
             open ? slideLeft.in : slideLeft.out,
           )}
         >
-          <button
+          <Button
             className="absolute right-4 top-4"
             onClick={() => setOpen(false)}
             aria-label="Close Menu"
           >
             <X className="h-5 w-5" />
-          </button>
+          </Button>
           <nav className="mt-8 flex flex-col gap-4 text-sm">
             <Link href="/" onClick={() => setOpen(false)}>
               Home

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          "border px-4 py-1 rounded transition-colors hover:bg-accent hover:text-accent-foreground",
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button }


### PR DESCRIPTION
## Summary
- create reusable `<Button>` component with hover styles
- replace button tags with `<Button>` in Navbar, StockSearch page, and HistorySearch

## Testing
- `pnpm typecheck`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6841d3ab1c84832f9709d3796881e33c