### PR TITLE
fix/stocks history search

### DIFF
--- a/app/stocks/page.tsx
+++ b/app/stocks/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useState, startTransition, Suspense, use } from 'react'
+import { useState, startTransition, Suspense, use, useRef } from 'react'
+import { flushSync } from 'react-dom'
 import HistorySearch from '@/components/history-search'
 import { StockPrice } from '@/utils/types'
 
@@ -10,6 +11,7 @@ interface PriceError {
 
 export default function StockSearchPage() {
   const [symbolInput, setSymbolInput] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
   const [pricePromise, setPricePromise] = useState<
     Promise<StockPrice | PriceError> | null
   >(null)
@@ -34,9 +36,10 @@ export default function StockSearchPage() {
       <h1 className="text-2xl font-bold">Stock Price Lookup</h1>
       <div className="flex gap-2">
         <input
+          ref={inputRef}
           className="border px-2 py-1 flex-1 rounded"
           value={symbolInput}
-          onChange={e => setSymbolInput(e.target.value)}
+          onChange={e => flushSync(() => setSymbolInput(e.target.value))}
           placeholder="Enter symbol e.g. AAPL"
         />
         <button className="border px-4 rounded" onClick={searchPrice}>
@@ -49,7 +52,7 @@ export default function StockSearchPage() {
         </Suspense>
       )}
 
-      <HistorySearch symbolInput={symbolInput} />
+      <HistorySearch symbolInput={symbolInput} inputRef={inputRef} />
     </div>
   )
 }

--- a/components/history-search.tsx
+++ b/components/history-search.tsx
@@ -1,11 +1,12 @@
 "use client"
 
-import { useState, useMemo, startTransition, Suspense, use } from 'react'
+import { useState, useMemo, Suspense, use, RefObject } from 'react'
 import DateSelect from '@/components/date-select'
 import ChartView from '@/components/chart-view'
 
 interface HistorySearchProps {
   symbolInput: string
+  inputRef: RefObject<HTMLInputElement | null>
 }
 
 interface HistoryItem {
@@ -21,7 +22,7 @@ interface HistoryError {
   error: string
 }
 
-export default function HistorySearch({ symbolInput }: HistorySearchProps) {
+export default function HistorySearch({ symbolInput, inputRef }: HistorySearchProps) {
   const yesterday = new Date()
   yesterday.setDate(yesterday.getDate() - 1)
   const today = new Date()
@@ -49,10 +50,9 @@ export default function HistorySearch({ symbolInput }: HistorySearchProps) {
   }, [historyParams])
 
   const searchHistory = () => {
-    if (!symbolInput.trim()) return
-    startTransition(() => {
-      setHistoryParams({ symbol: symbolInput.trim(), from, to, unit })
-    })
+    const symbol = inputRef.current?.value.trim() || symbolInput.trim()
+    if (!symbol) return
+    setHistoryParams({ symbol, from, to, unit })
   }
 
   return (

--- a/test/__tests__/HistorySearch.test.tsx
+++ b/test/__tests__/HistorySearch.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import StockSearchPage from '@/app/stocks/page'
+import { server } from '../server'
+import { http, HttpResponse } from 'msw'
+
+it('can change symbol after searching history', async () => {
+  const symbols: string[] = []
+  server.use(
+    http.get('/api/stocks/history', ({ request }) => {
+      const url = new URL(request.url)
+      symbols.push(url.searchParams.get('symbol')!)
+      return HttpResponse.json({ data: [] })
+    })
+  )
+
+  render(<StockSearchPage />)
+
+  const input = screen.getByPlaceholderText(/enter symbol/i)
+  const searchHistory = screen.getByText(/search history/i)
+
+  fireEvent.change(input, { target: { value: 'AAA' } })
+  fireEvent.click(searchHistory)
+  await waitFor(() => expect(symbols).toHaveLength(1))
+
+  fireEvent.change(input, { target: { value: 'BBB' } })
+  await waitFor(() => expect(input).toHaveValue('BBB'))
+  fireEvent.click(searchHistory)
+  await waitFor(() => expect(symbols).toHaveLength(2))
+
+  expect(symbols).toEqual(['AAA', 'BBB'])
+})
+
+it('can update period with same symbol', async () => {
+  const fromValues: string[] = []
+  server.use(
+    http.get('/api/stocks/history', ({ request }) => {
+      const url = new URL(request.url)
+      fromValues.push(url.searchParams.get('from')!)
+      return HttpResponse.json({ data: [] })
+    })
+  )
+
+  render(<StockSearchPage />)
+
+  const input = screen.getByPlaceholderText(/enter symbol/i)
+  const fromInput = screen.getByLabelText(/from/i)
+  const searchHistory = screen.getByText(/search history/i)
+
+  fireEvent.change(input, { target: { value: 'AAA' } })
+  fireEvent.click(searchHistory)
+  await waitFor(() => expect(fromValues).toHaveLength(1))
+
+  fireEvent.change(fromInput, { target: { value: '2024-01-02T00:00' } })
+  await waitFor(() => expect(fromInput).toHaveValue('2024-01-02T00:00'))
+  fireEvent.click(searchHistory)
+  await waitFor(() => expect(fromValues).toHaveLength(2))
+
+  expect(fromValues[1]).toBe('2024-01-02T00:00')
+})


### PR DESCRIPTION
## Summary
- ensure stock symbol updates before searching
- search history without transition for fresh parameters
- test history search to avoid regressions

## Testing
- `pnpm typecheck`
- `pnpm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6841d3314240832fbb7be62fa1d646c9